### PR TITLE
Use dotnet sdk docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
-FROM microsoft/powershell
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.13
 
 ADD ["entrypoint.ps1", "/data/"]
 
-RUN chmod +x /data/entrypoint.ps1 \
-    && apt-get update \
-    && apt-get install apt-transport-https wget --yes \
-    && wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install --yes dotnet-sdk-3.1
-
+RUN chmod +x /data/entrypoint.ps1
 
 ENTRYPOINT ["/data/entrypoint.ps1"]


### PR DESCRIPTION
I noticed recently that the dotnet sdk docker image now includes PowerShell Core and naturally the dotnet-sdk, so it may be preferable to use that docker image instead of manually installing the dotnet-sdk.