### PR TITLE
Prune output

### DIFF
--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -1,13 +1,6 @@
 #!/usr/bin/env pwsh
 
-Write-Host $env:INPUT_MODULEPATH
-Write-Host $env:INPUT_NUGETAPIKEY
-
-Get-ChildItem -Path env:
-Write-Host -Object ('Publishing module ({0}) to PowerShell Gallery' -f $env:INPUT_MODULEPATH)
-
-Get-ChildItem -Path $env:GITHUB_WORKSPACE | Format-Table -AutoSize
-Get-Module | Format-Table -AutoSize
+Write-Host "Publishing module ($env:INPUT_MODULEPATH) to PowerShell Gallery"
 
 Publish-Module -Path $env:INPUT_MODULEPATH -NuGetApiKey $env:INPUT_NUGETAPIKEY
-Write-Host -Object 'Finished publishing module to PowerShell Gallery'
+Write-Host 'Finished publishing module to PowerShell Gallery'


### PR DESCRIPTION
Most of this is debug level.  Printing out env variables can be a security vulnerability

Closes #3 