### PR TITLE
Make module path optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ For example, if you named your secret `PS_GALLERY_KEY`:
 
 ```
       - name: Publish Module to PowerShell Gallery
-        uses: pcgeek86/publish-powershell-module-action@v19
+        uses: pcgeek86/publish-powershell-module-action@v20
         id: publish-module
         with:
-          modulePath: YOURMODULENAME
           NuGetApiKey: ${{ secrets.PS_GALLERY_KEY }}
 ```
 
@@ -23,4 +22,3 @@ For example, if you named your secret `PS_GALLERY_KEY`:
 
 * You're writing a PowerShell script module (not a compiled module)
 * Your module is contained within a subfolder of your GitHub repository
-* Your module manifest's name is consistent with its parent directory

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
 name: Publish PowerShell Module
 description: Publishes a PowerShell module to the PowerShell Gallery.
 inputs:
-  modulePath:
-    description: The filesystem path to the module to import into the environment.
-    required: true
   NuGetApiKey:
     description: The NuGet API Key for PowerShell Gallery, with permission to push this module.
     required: true
+  modulePath:
+    description: The filesystem path to the module to publish.  If not provided, all directories that contains a .psd1 are published.
+    required: false
 outputs:
   successfullyPublished: # id of output
     description: Whether or not the publish command was successful

--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -1,7 +1,17 @@
 #!/usr/bin/env pwsh
 $ErrorActionPreference = 'Stop'
 
-Write-Host "Publishing module ($env:INPUT_MODULEPATH) to PowerShell Gallery"
+$Modules = $null
+if ([string]::IsNullOrWhiteSpace($env:INPUT_MODULEPATH)) {
+    $Modules = Get-ChildItem -Recurse -Filter '*.psd1' |
+        Select-Object -Unique -ExpandProperty Directory
+} else {
+    $Modules = @($env:INPUT_MODULEPATH)
+}
 
-Publish-Module -Path $env:INPUT_MODULEPATH -NuGetApiKey $env:INPUT_NUGETAPIKEY
-Write-Host 'Finished publishing module to PowerShell Gallery'
+$Modules | ForEach-Object {
+    Write-Host "Publishing '$_' to PowerShell Gallery"
+
+    Publish-Module -Path $_ -NuGetApiKey $env:INPUT_NUGETAPIKEY
+    Write-Host "'$_' published to PowerShell Gallery"
+}


### PR DESCRIPTION
Having to configure the path adds overhead / duplication.

Default behavior is now to discover module(s) to publish